### PR TITLE
less flashing on solo-logger

### DIFF
--- a/src/app/datalogger/solo-logger.c
+++ b/src/app/datalogger/solo-logger.c
@@ -39,12 +39,13 @@ static void turn_off_led(void *data) {
 }
 
 static void indicate_alive(void *data) {
-  schedule_us(2000000, indicate_alive, NULL);
-  gpio_set(ORANGE_LED);
+  schedule_us(30000000, indicate_alive, NULL);
   if (flash_dumper.ok && serial_reader_is_active(&psoc_console_tx)) {
+    gpio_set(ORANGE_LED);
+  } else {
     gpio_set(GREEN_LED);
   }
-  schedule_us(40000, turn_off_led, NULL);
+  schedule_us(3000, turn_off_led, NULL);
 }
 
 int main() {


### PR DESCRIPTION
flash one led every 30s: the orange one if there was new data written, the green one if there wasn't